### PR TITLE
FIx issue with warning about wrong data type in virtualizedCell

### DIFF
--- a/src/EventCalendar.js
+++ b/src/EventCalendar.js
@@ -100,7 +100,7 @@ export default class EventCalendar extends React.Component {
           data={events}
           getItemCount={() => this.props.size * 2}
           getItem={this._getItem.bind(this)}
-          keyExtractor={(item, index) => index}
+          keyExtractor={(item, index) => `${index}`}
           getItemLayout={this._getItemLayout.bind(this)}
           horizontal
           pagingEnabled


### PR DESCRIPTION
FIx issue with YellowBox "Warning: Failed child context type: Invalid child context `virtualizedCell.cellKey` of type `number` supplied to `CellRenderer`, expected `string`.
...